### PR TITLE
Is use of hsc2hs necessary?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,8 @@ endif
 # Source files, main and testing
 #
 
-FFI_SOURCES=\
-	$(shell find src -name '*.hsc' -type f)
-CORE_SOURCES=\
-	$(shell find src -name '*.hs' -type f) \
-	$(shell echo $(FFI_SOURCES) | perl -p -e 's/hsc$$/hs/; s{src}{$(BUILDDIR)/generated};')
-TEST_SOURCES=\
-	$(shell find tests -name '*.hs' -type f)
+CORE_SOURCES=$(shell find src -name '*.hs' -type f) 
+TEST_SOURCES=$(shell find tests -name '*.hs' -type f)
 
 
 %: $(BUILDDIR)/%.bin
@@ -83,9 +78,6 @@ $(BUILDDIR)/%.bin: config.h src/%.hs $(CORE_SOURCES) tags
 		-o $@ \
 		src/$*.hs
 
-%.hs: %.hsc
-	hsc2hs -o $@ $<
-
 tags: $(CORE_SOURCES) $(TEST_SOURCES)
 	@/bin/echo -e "CTAGS\ttags"
 	@hothasktags $^ > tags $(REDIRECT)
@@ -95,12 +87,6 @@ tags: $(CORE_SOURCES) $(TEST_SOURCES)
 #
 
 tests: config check
-
-$(BUILDDIR)/generated/%.hs: src/%.hsc
-	@if [ ! -d $(BUILDDIR)/generated ] ; then /bin/echo -e "MKDIR\t$(BUILDDIR)/generated" ; mkdir -p $(BUILDDIR)/generated ; fi
-	mkdir -p `dirname $@`
-	hsc2hs -o $@ $<
-
 
 $(BUILDDIR)/%.bin: config.h tests/%.hs $(CORE_SOURCES) $(TEST_SOURCES)
 	@if [ ! -d $(BUILDDIR) ] ; then /bin/echo -e "MKDIR\t$(BUILDDIR)" ; mkdir -p $(BUILDDIR) ; fi
@@ -141,7 +127,7 @@ clean:
 	-rm -f config.h
 
 
-format: $(FFI_SOURCES) $(CORE_SOURCES) $(TEST_SOURCES)
+format: $(CORE_SOURCES) $(TEST_SOURCES)
 	stylish-haskell -i $^
 
 #

--- a/rados-haskell.cabal
+++ b/rados-haskell.cabal
@@ -26,7 +26,6 @@ library
                        bytestring,
                        mtl
   hs-source-dirs:      src
-  build-tools:         hsc2hs
   default-language:    Haskell2010
   extra-libraries:     rados
 
@@ -42,7 +41,6 @@ test-suite             check
                        rados-haskell
   hs-source-dirs:      tests
   main-is:             check.hs
-  build-tools:         hsc2hs
   default-language:    Haskell2010
   extra-libraries:     rados
 

--- a/src/System/Rados/FFI.hs
+++ b/src/System/Rados/FFI.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE EmptyDataDecls           #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 
@@ -8,8 +7,6 @@ import Foreign
 import Foreign.C.Error
 import Foreign.C.String
 import Foreign.C.Types
-
-#include <rados/librados.h>
 
 -- typedef void *rados_t;
 data RadosT


### PR DESCRIPTION
Strangest thing. I went to all the trouble to hack support for _.hsc_ files into my build wrapper, then started looking at what the output from hsc2hs happened to be, and discovered it was essentially ... the same.

From which I realized that FFI works without requiring the _hsc2hs_ preprocessor, at least it appears to. So for the hell of it I stripped out the use of hsc2hs and converted _.hsc_ → _.hs_ and gave `make test` a go. Somewhat to my surprise, it built and checked.

Makes for an annoying diff off the command line because of Git's pathologically useless approach to file renames; something GitHub presents better.

AfC
